### PR TITLE
feat: respect users' preferred color scheme

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -126,6 +126,9 @@ const config: Config = {
     //     '<a target="_blank" href="https://github.com/react-native-google-signin/google-signin/issues/1259">Bridgeless mode</a> support is now publicly available!',
     //   isCloseable: true,
     // },
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     image: 'img/docusaurus-social-card.jpg',
     navbar: {
       title: 'RN Google Sign In',


### PR DESCRIPTION
These are the changes to the [Docusaurus theme config](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode) so that it prefers the user's system color scheme instead of just defaulting to the light one.