### PR TITLE
[Docs] Updating setting-up docs so that it's clearer that configuartion section is required

### DIFF
--- a/docs/setting-up/_category_.json
+++ b/docs/setting-up/_category_.json
@@ -4,6 +4,6 @@
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "description": "Learn how to install and configure the package for different platforms"
+    "description": "Learn how to install and configure the package for different platforms. (Note that the Obtaining Configuration Information section is required for all platforms.)"
   }
 }

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -75,8 +75,11 @@ Then run the following to generate the native project directories. Run this comm
 npx expo prebuild --clean
 ```
 
-Next, rebuild your app and you're good to go! Now you're ready to [set up your configuration files](/docs/setting-up/get-config-file).
+Next, rebuild your app and you're good to go!
 
 ```sh
 npx expo run:android && npx expo run:ios
 ```
+
+Now you're ready to [set up your configuration files](/docs/setting-up/get-config-file).
+

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -75,7 +75,7 @@ Then run the following to generate the native project directories. Run this comm
 npx expo prebuild --clean
 ```
 
-Next, rebuild your app and you're good to go!
+Next, rebuild your app and you're good to go! Now you're ready to (set up your configuration files)[/docs/setting-up/get-config-file].
 
 ```sh
 npx expo run:android && npx expo run:ios

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -80,6 +80,3 @@ Next, rebuild your app and you're good to go!
 ```sh
 npx expo run:android && npx expo run:ios
 ```
-
-Now you're ready to [set up your configuration files](/docs/setting-up/get-config-file).
-

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -75,7 +75,7 @@ Then run the following to generate the native project directories. Run this comm
 npx expo prebuild --clean
 ```
 
-Next, rebuild your app and you're good to go! Now you're ready to (set up your configuration files)[/docs/setting-up/get-config-file].
+Next, rebuild your app and you're good to go! Now you're ready to [set up your configuration files](/docs/setting-up/get-config-file).
 
 ```sh
 npx expo run:android && npx expo run:ios


### PR DESCRIPTION
I wasted some time trying to debug my setup because I didn't see the "Obtaining configuration information" section - I saw the rest of the "Setting up" section was native/web, and just ignored it, not realizing that the final page of the "Setting-up" subsection applies to everyone. 

My own fault, but I think it's a mistake easily made, so this PR aims to try to save future developers the same headache by adding some pointers to make sure they realize that the "Obtaining configuration information" section is required for everyone. 

It's possible some similar pointers in the Android/iOS/Web sections would be helpful as well, but I'm not actually familiar with those processes so I didn't want to assume. 