### PR TITLE
Update Expo instructions

### DIFF
--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -14,7 +14,7 @@ With Expo SDK 50, minimum iOS version was bumped to 13.4. In case you get an err
 
 :::note
 
-This package cannot be used in [Expo Go](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it requires custom native code. This applies to both the [original](../original)  and [modern](../one-tap) (one-tap) sign in methods 
+This package cannot be used in [Expo Go](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it requires custom native code. This applies to both the [original](../original)  and [modern](../one-tap) (one-tap) sign in methods.
 
 However, you can add custom native code to an Expo app by using a [development build](https://docs.expo.dev/workflow/overview/#development-builds). Using a development build is the recommended approach for production apps, and is documented in this guide.
 

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -14,7 +14,7 @@ With Expo SDK 50, minimum iOS version was bumped to 13.4. In case you get an err
 
 :::note
 
-This package cannot be used in [Expo Go](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it requires custom native code.
+This package cannot be used in [Expo Go](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it requires custom native code. This applies to both the [original](../original)  and [modern](../one-tap) (one-tap) sign in methods 
 
 However, you can add custom native code to an Expo app by using a [development build](https://docs.expo.dev/workflow/overview/#development-builds). Using a development build is the recommended approach for production apps, and is documented in this guide.
 
@@ -74,6 +74,13 @@ Then run the following to generate the native project directories. Run this comm
 ```sh
 npx expo prebuild --clean
 ```
+
+This will generate native project directories. [Expo recommends](https://docs.expo.dev/workflow/continuous-native-generation/#usage-with-eas-build) adding these directories to your `.gitignore` if you haven't already:
+```sh
+/android
+/ios
+```
+
 
 Next, rebuild your app and you're good to go!
 

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -14,7 +14,7 @@ With Expo SDK 50, minimum iOS version was bumped to 13.4. In case you get an err
 
 :::note
 
-This package cannot be used in [Expo Go](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it requires custom native code. This applies to both the [original](../original)  and [modern](../one-tap) (one-tap) sign in methods.
+This package cannot be used in [Expo Go](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it requires custom native code. This applies to both the [original](../original) and [modern](../one-tap) (one-tap) sign in methods.
 
 However, you can add custom native code to an Expo app by using a [development build](https://docs.expo.dev/workflow/overview/#development-builds). Using a development build is the recommended approach for production apps, and is documented in this guide.
 

--- a/docs/setting-up/expo.md
+++ b/docs/setting-up/expo.md
@@ -75,13 +75,6 @@ Then run the following to generate the native project directories. Run this comm
 npx expo prebuild --clean
 ```
 
-This will generate native project directories. [Expo recommends](https://docs.expo.dev/workflow/continuous-native-generation/#usage-with-eas-build) adding these directories to your `.gitignore` if you haven't already:
-```sh
-/android
-/ios
-```
-
-
 Next, rebuild your app and you're good to go!
 
 ```sh


### PR DESCRIPTION
- Clarifies that both approaches require ejecting from Expo Go
- Adds .gitignore recommendation